### PR TITLE
[김일규] step-1 index.html 응답

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ Java Web Application Server 2023
 
 이 프로젝트는 우아한 테크코스 박재성님의 허가를 받아 https://github.com/woowacourse/jwp-was 
 를 참고하여 작성되었습니다.
+
+## 학습 정리
+- Java Thread Model: https://github.com/SyuA0529/be-was/wiki/Java-Thread
+- Java Concurrent Package: https://github.com/SyuA0529/be-was/wiki/Java-Concurrent-Package

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ dependencies {
     implementation 'com.github.jknack:handlebars:4.2.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation 'org.assertj:assertj-core:3.16.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ repositories {
 
 dependencies {
 
-    implementation 'ch.qos.logback:logback-classic:1.2.3'
-    implementation 'com.google.guava:guava:29.0-jre'
-    implementation 'ch.qos.logback:logback-classic:1.2.3'
+    implementation 'ch.qos.logback:logback-classic:1.2.9'
+    implementation 'com.google.guava:guava:30.0-jre'
+    implementation 'ch.qos.logback:logback-classic:1.2.9'
     implementation 'com.github.jknack:handlebars:4.2.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'

--- a/src/main/java/db/Database.java
+++ b/src/main/java/db/Database.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 import java.util.Map;
 
 public class Database {
-    private static Map<String, User> users = Maps.newHashMap();
+    private static final Map<String, User> users = Maps.newHashMap();
 
     public static void addUser(User user) {
         users.put(user.getUserId(), user);

--- a/src/main/java/model/User.java
+++ b/src/main/java/model/User.java
@@ -1,10 +1,10 @@
 package model;
 
 public class User {
-    private String userId;
-    private String password;
-    private String name;
-    private String email;
+    private final String userId;
+    private final String password;
+    private final String name;
+    private final String email;
 
     public User(String userId, String password, String name, String email) {
         this.userId = userId;

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,18 +1,24 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.Socket;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.http.HttpRequest;
+import webserver.http.HttpRequestParser;
+import webserver.http.HttpRequestParserImpl;
+import webserver.view.View;
+import webserver.view.ViewResolver;
+import webserver.view.HtmlViewResolverImpl;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+    private final HttpRequestParser httpRequestParser = new HttpRequestParserImpl();
+    private final ViewResolver viewResolver = new HtmlViewResolverImpl();
 
-    private Socket connection;
+    private final Socket connection;
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
@@ -23,13 +29,29 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
+            HttpRequest httpRequest = httpRequestParser.parse(in);
+            logAllHeader(httpRequest);
+
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
             byte[] body = "Hello World".getBytes();
+
+            if(httpRequest.getUri().equals("/index.html")) {
+                View view = viewResolver.resolveView(httpRequest.getUri());
+                body = view.render(dos);
+            }
+
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
+        }
+    }
+
+    private static void logAllHeader(HttpRequest httpRequest) {
+        Set<String> headerNames = httpRequest.getHeaderNames();
+        for (String headerName : headerNames) {
+            logger.debug("Header {}: {}", headerName, httpRequest.getHeader(headerName));
         }
     }
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -25,21 +25,19 @@ public class RequestHandler implements Runnable {
     }
 
     public void run() {
-        logger.debug("New Client Connect! Connected IP : {}, Port : {}", connection.getInetAddress(),
-                connection.getPort());
+        logger.debug("New Client Connect! Connected IP : {}, Port : {}",
+                connection.getInetAddress(), connection.getPort());
 
-        try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
+        try (InputStream in = connection.getInputStream();
+             OutputStream out = connection.getOutputStream()) {
             HttpRequest httpRequest = httpRequestParser.parse(in);
             logAllHeader(httpRequest);
 
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "Hello World".getBytes();
 
-            if(httpRequest.getUri().equals("/index.html")) {
-                View view = viewResolver.resolveView(httpRequest.getUri());
-                body = view.render(dos);
-            }
+            View view = viewResolver.resolve(httpRequest.getUri());
+            byte[] body = view.render(dos);
 
             response200Header(dos, body.length);
             responseBody(dos, body);

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,6 +2,8 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,23 +12,21 @@ public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
     private static final int DEFAULT_PORT = 8080;
 
-    public static void main(String args[]) throws Exception {
-        int port = 0;
-        if (args == null || args.length == 0) {
-            port = DEFAULT_PORT;
-        } else {
+    public static void main(String[] args) throws Exception {
+        int port = DEFAULT_PORT;
+        if (args != null && args.length != 0) {
             port = Integer.parseInt(args[0]);
         }
 
-        // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
+        ExecutorService executorService = Executors.newFixedThreadPool(
+                Runtime.getRuntime().availableProcessors());
+
         try (ServerSocket listenSocket = new ServerSocket(port)) {
             logger.info("Web Application Server started {} port.", port);
 
-            // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                executorService.execute(new RequestHandler(connection));
             }
         }
     }

--- a/src/main/java/webserver/http/HttpHeaders.java
+++ b/src/main/java/webserver/http/HttpHeaders.java
@@ -1,0 +1,25 @@
+package webserver.http;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class HttpHeaders {
+    private final Map<String, String> headers;
+
+    public HttpHeaders() {
+        this.headers = new HashMap<>();
+    }
+
+    public void addHeader(String headerName, String value) {
+        headers.put(headerName, value);
+    }
+
+    public String getHeaderValues(String headerName) {
+        return headers.getOrDefault(headerName, null);
+    }
+
+    public Set<String> getHeaderNames() {
+        return headers.keySet();
+    }
+}

--- a/src/main/java/webserver/http/HttpMethod.java
+++ b/src/main/java/webserver/http/HttpMethod.java
@@ -1,0 +1,5 @@
+package webserver.http;
+
+public enum HttpMethod {
+    GET, POST, PUT, PATCH, DELETE
+}

--- a/src/main/java/webserver/http/HttpRequest.java
+++ b/src/main/java/webserver/http/HttpRequest.java
@@ -1,0 +1,30 @@
+package webserver.http;
+
+
+import java.util.Set;
+
+public abstract class HttpRequest {
+    public abstract HttpMethod getMethod();
+    public abstract String getUri();
+    public abstract String getVersion();
+    public abstract Set<String> getHeaderNames();
+    public abstract String getHeader(String headerName);
+    //TODO: Object 나중에 바꿀 것
+    public abstract Object getBody();
+    public static Builder builder() {
+        return new HttpRequestBuilderImpl();
+    }
+
+    public interface Builder {
+
+        Builder method(HttpMethod httpMethod);
+
+        Builder uri(String uri);
+
+        Builder version(String version);
+
+        Builder addHeader(String headerName, String value);
+
+        HttpRequest build();
+    }
+}

--- a/src/main/java/webserver/http/HttpRequestBuilderImpl.java
+++ b/src/main/java/webserver/http/HttpRequestBuilderImpl.java
@@ -4,7 +4,7 @@ public class HttpRequestBuilderImpl implements HttpRequest.Builder {
     private HttpMethod method;
     private String uri;
     private String version;
-    private HttpHeaders headers;
+    private final HttpHeaders headers;
 
     public HttpRequestBuilderImpl() {
         this.headers = new HttpHeaders();

--- a/src/main/java/webserver/http/HttpRequestBuilderImpl.java
+++ b/src/main/java/webserver/http/HttpRequestBuilderImpl.java
@@ -1,0 +1,41 @@
+package webserver.http;
+
+public class HttpRequestBuilderImpl implements HttpRequest.Builder {
+    private HttpMethod method;
+    private String uri;
+    private String version;
+    private HttpHeaders headers;
+
+    public HttpRequestBuilderImpl() {
+        this.headers = new HttpHeaders();
+    }
+
+    @Override
+    public HttpRequest.Builder method(HttpMethod method) {
+        this.method = method;
+        return this;
+    }
+
+    @Override
+    public HttpRequest.Builder uri(String uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    @Override
+    public HttpRequest.Builder version(String version) {
+        this.version = version;
+        return this;
+    }
+
+    @Override
+    public HttpRequest.Builder addHeader(String headerName, String value) {
+        headers.addHeader(headerName, value);
+        return this;
+    }
+
+    @Override
+    public HttpRequest build() {
+        return new HttpRequestImpl(method, uri, version, headers);
+    }
+}

--- a/src/main/java/webserver/http/HttpRequestImpl.java
+++ b/src/main/java/webserver/http/HttpRequestImpl.java
@@ -1,0 +1,50 @@
+package webserver.http;
+
+import java.util.Set;
+
+public class HttpRequestImpl extends HttpRequest {
+    private final HttpMethod httpMethod;
+    private final String uri;
+    private final String version;
+    private final HttpHeaders headers;
+
+    public HttpRequestImpl(HttpMethod httpMethod,
+                           String uri,
+                           String version,
+                           HttpHeaders headers) {
+            this.httpMethod = httpMethod;
+            this.uri = uri;
+            this.version = version;
+            this.headers = headers;
+    }
+
+    @Override
+    public HttpMethod getMethod() {
+        return httpMethod;
+    }
+
+    @Override
+    public String getUri() {
+        return uri;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public Set<String> getHeaderNames() {
+        return headers.getHeaderNames();
+    }
+
+    @Override
+    public String getHeader(String headerName) {
+        return headers.getHeaderValues(headerName);
+    }
+
+    @Override
+    public Object getBody() {
+        return null;
+    }
+}

--- a/src/main/java/webserver/http/HttpRequestParser.java
+++ b/src/main/java/webserver/http/HttpRequestParser.java
@@ -1,0 +1,8 @@
+package webserver.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface HttpRequestParser {
+    HttpRequest parse(InputStream inputStream) throws IOException;
+}

--- a/src/main/java/webserver/http/HttpRequestParserImpl.java
+++ b/src/main/java/webserver/http/HttpRequestParserImpl.java
@@ -25,7 +25,7 @@ public class HttpRequestParserImpl implements HttpRequestParser {
     }
 
     private static void parseHeaders(HttpRequest.Builder builder, BufferedReader bufferedReader) throws IOException {
-        String line = null;
+        String line;
         while(!(line = bufferedReader.readLine()).isBlank()) {
             String[] header = line.split(": ");
             builder.addHeader(header[0].trim(), header[1].trim());

--- a/src/main/java/webserver/http/HttpRequestParserImpl.java
+++ b/src/main/java/webserver/http/HttpRequestParserImpl.java
@@ -1,0 +1,34 @@
+package webserver.http;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class HttpRequestParserImpl implements HttpRequestParser {
+    @Override
+    public HttpRequest parse(InputStream inputStream) throws IOException {
+        HttpRequest.Builder builder = HttpRequest.builder();
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+
+        parseStartLine(builder, bufferedReader);
+        parseHeaders(builder, bufferedReader);
+
+        return builder.build();
+    }
+
+    private static void parseStartLine(HttpRequest.Builder builder, BufferedReader bufferedReader) throws IOException {
+        String[] startLine = bufferedReader.readLine().split(" ");
+        builder.method(HttpMethod.valueOf(startLine[0].trim()));
+        builder.uri(startLine[1].trim());
+        builder.version(startLine[2].substring(startLine[2].indexOf('/') + 1));
+    }
+
+    private static void parseHeaders(HttpRequest.Builder builder, BufferedReader bufferedReader) throws IOException {
+        String line = null;
+        while(!(line = bufferedReader.readLine()).isBlank()) {
+            String[] header = line.split(": ");
+            builder.addHeader(header[0].trim(), header[1].trim());
+        }
+    }
+}

--- a/src/main/java/webserver/view/HtmlView.java
+++ b/src/main/java/webserver/view/HtmlView.java
@@ -1,0 +1,19 @@
+package webserver.view;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class HtmlView implements View {
+    private final File html;
+
+    public HtmlView(File html) {
+        this.html = html;
+    }
+
+    @Override
+    public byte[] render(DataOutputStream dataOutputStream) throws IOException {
+        return Files.readAllBytes(html.toPath());
+    }
+}

--- a/src/main/java/webserver/view/HtmlViewResolverImpl.java
+++ b/src/main/java/webserver/view/HtmlViewResolverImpl.java
@@ -1,0 +1,12 @@
+package webserver.view;
+
+import java.io.File;
+
+public class HtmlViewResolverImpl implements ViewResolver {
+    private static final String HTML_PREFIX_URI = "src/main/resources/templates";
+
+    @Override
+    public View resolveView(String viewPath) {
+        return new HtmlView(new File(HTML_PREFIX_URI + viewPath));
+    }
+}

--- a/src/main/java/webserver/view/HtmlViewResolverImpl.java
+++ b/src/main/java/webserver/view/HtmlViewResolverImpl.java
@@ -3,10 +3,30 @@ package webserver.view;
 import java.io.File;
 
 public class HtmlViewResolverImpl implements ViewResolver {
-    private static final String HTML_PREFIX_URI = "src/main/resources/templates";
+    private static final String HTML_PREFIX = "src/main/resources/templates";
+    private static final String HTML_SUFFIX = ".html";
+    private static final String DEFAULT_VIEW_PATH = "/errors/404.html";
 
     @Override
-    public View resolveView(String viewPath) {
-        return new HtmlView(new File(HTML_PREFIX_URI + viewPath));
+    public View resolve(String viewUri) {
+        File html = new File(getViewPath(viewUri));
+        return createView(html);
+    }
+
+    private static View createView(File html) {
+        if (html.exists() && html.canRead()) {
+            return new HtmlView(html);
+        }
+        return new HtmlView(new File(HTML_PREFIX + DEFAULT_VIEW_PATH));
+    }
+
+    private static String getViewPath(String viewUri) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(HTML_PREFIX)
+                .append(viewUri);
+        if (!viewUri.endsWith(HTML_SUFFIX)) {
+            stringBuilder.append(HTML_SUFFIX);
+        }
+        return stringBuilder.toString();
     }
 }

--- a/src/main/java/webserver/view/View.java
+++ b/src/main/java/webserver/view/View.java
@@ -1,0 +1,8 @@
+package webserver.view;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public interface View {
+    byte[] render(DataOutputStream dataOutputStream) throws IOException;
+}

--- a/src/main/java/webserver/view/ViewResolver.java
+++ b/src/main/java/webserver/view/ViewResolver.java
@@ -2,5 +2,5 @@ package webserver.view;
 
 
 public interface ViewResolver {
-    View resolveView(String viewPath);
+    View resolve(String viewPath);
 }

--- a/src/main/java/webserver/view/ViewResolver.java
+++ b/src/main/java/webserver/view/ViewResolver.java
@@ -1,0 +1,6 @@
+package webserver.view;
+
+
+public interface ViewResolver {
+    View resolveView(String viewPath);
+}

--- a/src/main/resources/templates/errors/404.html
+++ b/src/main/resources/templates/errors/404.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>404 Not Found</title>
+</head>
+<body>
+404 Not Found
+</body>
+</html>

--- a/src/test/java/webserver/http/HttpRequestBuilderImplTest.java
+++ b/src/test/java/webserver/http/HttpRequestBuilderImplTest.java
@@ -1,0 +1,115 @@
+package webserver.http;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("HTTP 요청 객체 빌더 테스트")
+class HttpRequestBuilderImplTest {
+    HttpRequest.Builder builder;
+
+    @BeforeEach
+    void setup() {
+        builder = new HttpRequestBuilderImpl();
+    }
+
+    @Nested
+    @DisplayName("method method")
+    class method {
+        @Test
+        @DisplayName("method 필드가 저장된 빌더를 반환한다")
+        void returnBuilderSetMethodField() throws NoSuchFieldException, IllegalAccessException {
+            //given
+            //when
+            HttpRequest.Builder resultBuilder = builder.method(HttpMethod.DELETE);
+
+            //then
+            Field methodField = resultBuilder.getClass().getDeclaredField("method");
+            methodField.setAccessible(true);
+            assertThat(methodField.get(resultBuilder)).isEqualTo(HttpMethod.DELETE);
+        }
+    }
+
+    @Nested
+    @DisplayName("uri method")
+    class Uri {
+        @Test
+        @DisplayName("uri 필드가 저장된 빌더를 반환한다")
+        void returnBuilderSetUriField() throws NoSuchFieldException, IllegalAccessException {
+            //given
+            //when
+            HttpRequest.Builder resultBuilder = builder.uri("/index.html");
+
+            //then
+            Field uriField = resultBuilder.getClass().getDeclaredField("uri");
+            uriField.setAccessible(true);
+            assertThat(uriField.get(resultBuilder)).isEqualTo("/index.html");
+        }
+    }
+
+    @Nested
+    @DisplayName("version method")
+    class Version {
+        @Test
+        @DisplayName("version 필드가 저장된 빌더를 반환한다")
+        void returnBuilderSetUriField() throws NoSuchFieldException, IllegalAccessException {
+            //given
+            //when
+            HttpRequest.Builder resultBuilder = builder.version("1.1");
+
+            //then
+            Field versionField = resultBuilder.getClass().getDeclaredField("version");
+            versionField.setAccessible(true);
+            assertThat(versionField.get(resultBuilder)).isEqualTo("1.1");
+        }
+    }
+
+    @Nested
+    @DisplayName("headers method")
+    class Headers {
+        @Test
+        @DisplayName("headers 필드가 저장된 빌더를 반환한다")
+        void returnBuilderSetVersionField() throws NoSuchFieldException, IllegalAccessException {
+            //given
+            //when
+            HttpRequest.Builder resultBuilder = builder.addHeader("header1", "header1");
+
+            //then
+            Field headersField = resultBuilder.getClass().getDeclaredField("headers");
+            headersField.setAccessible(true);
+
+            Object headers = headersField.get(resultBuilder);
+            assertThat(headers).isInstanceOf(HttpHeaders.class);
+            assertThat(((HttpHeaders) headers).getHeaderValues("header1")).isEqualTo("header1");
+        }
+    }
+
+    @Nested
+    @DisplayName("build method")
+    class Build {
+        @Test
+        @DisplayName("지금까지 지정한 내용을 통해 HttpRequest 객체를 생성하고 반환한다")
+        void returnHttpRequest() {
+            //given
+            builder.method(HttpMethod.GET);
+            builder.uri("/index.html");
+            builder.version("1.1");
+            builder.addHeader("header1", "header1");
+
+            //when
+            HttpRequest httpRequest = builder.build();
+
+            //then
+            assertThat(httpRequest.getMethod()).isEqualTo(HttpMethod.GET);
+            assertThat(httpRequest.getUri()).isEqualTo("/index.html");
+            assertThat(httpRequest.getVersion()).isEqualTo("1.1");
+            assertThat(httpRequest.getHeader("header1")).isEqualTo("header1");
+        }
+    }
+}

--- a/src/test/java/webserver/http/HttpRequestBuilderImplTest.java
+++ b/src/test/java/webserver/http/HttpRequestBuilderImplTest.java
@@ -10,7 +10,7 @@ import java.lang.reflect.Field;
 
 import static org.assertj.core.api.Assertions.*;
 
-@DisplayName("HTTP 요청 객체 빌더 테스트")
+@DisplayName("HttpRequestBuilderImpl 테스트")
 class HttpRequestBuilderImplTest {
     HttpRequest.Builder builder;
 

--- a/src/test/java/webserver/http/HttpRequestParserImplTest.java
+++ b/src/test/java/webserver/http/HttpRequestParserImplTest.java
@@ -1,0 +1,101 @@
+package webserver.http;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@DisplayName("Http 요청 파서 테스트")
+class HttpRequestParserImplTest {
+    HttpRequestParser httpRequestParser = new HttpRequestParserImpl();
+    static String httpMessage =
+            "GET /index.html HTTP/1.1\r\n" +
+            "Host: localhost:8080\r\n" +
+            "Connection: keep-alive\r\n" +
+            "sec-ch-ua: \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"114\", \"Google Chrome\";v=\"114\"\r\n" +
+            "sec-ch-ua-mobile: ?0\r\n" +
+            "sec-ch-ua-platform: \"macOS\"\r\n" +
+            "Upgrade-Insecure-Requests: 1\r\n" +
+            "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36\r\n" +
+            "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7\r\n" +
+            "Sec-Fetch-Site: none\r\n" +
+            "Sec-Fetch-Mode: navigate\r\n" +
+            "Sec-Fetch-User: ?1\r\n" +
+            "Sec-Fetch-Dest: document\r\n" +
+            "Accept-Encoding: gzip, deflate, br\r\n" +
+            "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7\r\n" +
+            "Cookie: Idea-13020a74=01685f19-8588-4907-88e8-60ee76288f21\r\n"
+            +"\r\n" +
+            "BodyBodyBody\r\n";
+
+    @Nested
+    @DisplayName("parse method")
+    class parse {
+        @Test
+        @DisplayName("HTTP 요청 메세지의 정보를 담고있는 HttpRequest 객체를 반환한다")
+        void returnHttpRequest() throws IOException {
+            //given
+            HashMap<String, String> expectHeaders = getExpectHeaders();
+            InputStream inputStream = new ByteArrayInputStream(httpMessage.getBytes());
+
+            //when
+            HttpRequest httpRequest = httpRequestParser.parse(inputStream);
+
+            //then
+            verifyStartLine(httpRequest, HttpMethod.GET, "/index.html", "1.1");
+            verifyHeaders(httpRequest, expectHeaders);
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static void verifyStartLine(HttpRequest httpRequest,
+                                        HttpMethod method,
+                                        String uri,
+                                        String version) {
+        assertThat(httpRequest.getMethod()).isEqualTo(method);
+        assertThat(httpRequest.getUri()).isEqualTo(uri);
+        assertThat(httpRequest.getVersion()).isEqualTo(version);
+    }
+
+    private static void verifyHeaders(HttpRequest httpRequest,
+                                        Map<String, String> headerInfos) {
+        for (String headerName : headerInfos.keySet()) {
+            verifyHeader(httpRequest, headerInfos, headerName);
+        }
+    }
+
+    private static void verifyHeader(HttpRequest httpRequest, Map<String, String> headerInfos, String headerName) {
+        String expectValue = headerInfos.get(headerName);
+        String resultValue = httpRequest.getHeader(headerName);
+        assertThat(resultValue).isEqualTo(expectValue);
+    }
+
+    private static HashMap<String, String> getExpectHeaders() {
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put("Host", "localhost:8080");
+        headers.put("Connection", "keep-alive");
+        headers.put("sec-ch-ua", "\"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"114\", \"Google Chrome\";v=\"114\"");
+        headers.put("sec-ch-ua-mobile", "?0");
+        headers.put("sec-ch-ua-platform", "\"macOS\"");
+        headers.put("Upgrade-Insecure-Requests", "1");
+        headers.put("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36");
+        headers.put("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7");
+        headers.put("Sec-Fetch-Site", "none");
+        headers.put("Sec-Fetch-Mode", "navigate");
+        headers.put("Sec-Fetch-User", "?1");
+        headers.put("Sec-Fetch-Dest", "document");
+        headers.put("Accept-Encoding", "gzip, deflate, br");
+        headers.put("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7");
+        headers.put("Cookie", "Idea-13020a74=01685f19-8588-4907-88e8-60ee76288f21");
+        return headers;
+    }
+}

--- a/src/test/java/webserver/http/HttpRequestParserImplTest.java
+++ b/src/test/java/webserver/http/HttpRequestParserImplTest.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.*;
 
 
-@DisplayName("Http 요청 파서 테스트")
+@DisplayName("HttpRequestParserImpl 테스트")
 class HttpRequestParserImplTest {
     HttpRequestParser httpRequestParser = new HttpRequestParserImpl();
     static String httpMessage =

--- a/src/test/java/webserver/view/HtmlViewResolverImplTest.java
+++ b/src/test/java/webserver/view/HtmlViewResolverImplTest.java
@@ -1,0 +1,58 @@
+package webserver.view;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@DisplayName("HtmlViewResolverImpl 테스트")
+class HtmlViewResolverImplTest {
+    ViewResolver viewResolver = new HtmlViewResolverImpl();
+
+    @Nested
+    @DisplayName("resolve method")
+    class Resolve {
+        @Nested
+        @DisplayName("viewPath에 해당하는 파일이 존재한다면")
+        class isFileExist {
+            @Test
+            @DisplayName("viewPath에 해당하는 파일의 경로를 갖는 View 객체를 반환한다")
+            void returnView() throws NoSuchFieldException, IllegalAccessException {
+                //given
+                //when
+                View indexView = viewResolver.resolve("/index.html");
+
+                //then
+                Field htmlField = indexView.getClass().getDeclaredField("html");
+                htmlField.setAccessible(true);
+                Object result = htmlField.get(indexView);
+                assertThat(result).isInstanceOf(File.class);
+                assertThat(((File) result).getName()).isEqualTo("index.html");
+            }
+        }
+
+        @Nested
+        @DisplayName("viewPath에 해당하는 파일이 존재하지 않는다면")
+        class isFileNotExist {
+            @Test
+            @DisplayName("404.html 파일의 경로를 갖는 View 객체를 반환한다")
+            void return404View() throws NoSuchFieldException, IllegalAccessException {
+                //given
+                //when
+                View notFoundView = viewResolver.resolve("/notExist");
+
+                //then
+                Field htmlField = notFoundView.getClass().getDeclaredField("html");
+                htmlField.setAccessible(true);
+                Object result = htmlField.get(notFoundView);
+                assertThat(result).isInstanceOf(File.class);
+                assertThat(((File) result).getName()).isEqualTo("404.html");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 구현 내용
- [x] 학습한 내용을 README.md와 GitHub 위키를 이용해서 기록
- [x] 요청이 들어오면 src/main/resources/templates 경로의 파일에서 uri에 해당하는 파일의 내용을 읽어 응답하도록 구현
    - HTTP 요청을 해석하기 위한 파서 구현
    - 클라이언트에게 제공할 페이지 내용(byte array)를 제공하는 View 구현
    - 클라이언트에게 제공할 View를 찾는 ViewResolver 구현
- [x] Java Thread를 직접 생성하지 않고 Concurrent 패키지를 통해 스레드 풀을 사용하도록 변경

## 고민 사항
- 스레드가 너무 많이 생성되는 것을 막기 위해 고정된 개수의 스레드만을 사용하는 스레드 풀을 생성할 때 몇 개의 스레드를 생성하는 것이 적절한지 고민하였다. 이상적인 스레드 풀의 적정 크기를 계산하기 위해서는 사용 가능한 코어 개수, 목표 CPU 사용량, 대기 시간, 서비스 시간 정보가 필요하나 대기 시간과 서비스 시간을 아직 잘 알지 못하기 때문에 사용 가능한 코어 개수만큼의 스레드만을 확보하도록 설정하였다.
- 추상적인 개념을 정의할 때 추상 클래스로 정의해야 되는지, 인터페이스로 정의해야되는지 아직 잘 감이 오지 않는다. java.net.http 패키지의 클래스를 살짝 보니 빌더가 존재하는 HttpRequest는 추상 클래스로, 빌더가 존재하지 않는 HttpResponse는 인터페이스로 구현되어 있어 동일한 방식으로 구현했으나 옳은 구현인지는 아직 잘 모르겠다.
## 기타
스프링은 정말 위대하다. 너무나도 많은 것들을 알아서 처리해 준다.
